### PR TITLE
fernflower: init at unstable-2022-12-30

### DIFF
--- a/pkgs/tools/security/fernflower/default.nix
+++ b/pkgs/tools/security/fernflower/default.nix
@@ -1,0 +1,36 @@
+{ lib, stdenv, fetchgit, jre, gradle }:
+
+let
+  pname = "fernflower";
+  version = "unstable-2022-12-30";
+in stdenv.mkDerivation rec {
+  inherit pname version;
+  
+  name = "${pname}-${version}";
+
+  src = fetchgit {
+    url = "https://github.com/fesh0r/fernflower";
+    rev = "25df654fb5cc76d4e05e0c801d44f65c73fcee26";
+    hash = "sha256-43srhW4UzyL5HdqfAluvheZJ5CW6W9VimlnOPeI3qns=";
+  };
+  
+  nativeBuildInputs = [ gradle ];
+
+  buildInputs = [ jre ];
+
+  buildPhase = ''
+  '';
+
+  installPhase = ''
+  '';
+
+  meta = with lib; {
+    description = "An analytical decompiler for Java";
+    longDescription = "Fernflower is the first actually working analytical decompiler for Java and probably for a high-level programming language in general.";
+    homepage = "https://github.com/JetBrains/intellij-community/tree/master/plugins/java-decompiler/engine";
+    downloadPage = "https://github.com/fesh0r/fernflower";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7252,6 +7252,8 @@ with pkgs;
     mkFranzDerivation = callPackage ../applications/networking/instant-messengers/franz/generic.nix { };
   };
 
+  fernflower = callPackage ../tools/security/fernflower { };
+
   fq = callPackage ../development/tools/fq { };
 
   franz = callPackage ../applications/networking/instant-messengers/franz {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


fernflower